### PR TITLE
fix: Add error type handling for anonymous type

### DIFF
--- a/src/JsonDataMaskingFramework.Test/JsonMaskTests.cs
+++ b/src/JsonDataMaskingFramework.Test/JsonMaskTests.cs
@@ -334,6 +334,24 @@ namespace JsonDataMaskingFramework.Test
         }
 
         [Fact]
+        public void MaskSensitiveData_MasksProperty_WhenDataHasAnonymousType()
+        {
+            // Arrange
+            var customer = new CustomerMock
+            {
+                FullName = "John Doe"
+            };
+            var anonymousObj = new { customer };
+            var expectedObj = new CustomerMock { FullName = "*****" };
+            
+            // Act
+            var maskedAnonymousObj = JsonMask.MaskSensitiveData(anonymousObj);
+
+            // Assert
+            Assert.Equal(expectedObj.FullName, maskedAnonymousObj.customer.FullName);
+        }
+
+        [Fact]
         public void MaskSensitiveData_DoesNotEnterInfiniteLoop_WhenDataHasACycle()
         {
             // Arrange

--- a/src/JsonDataMaskingFramework/Masks/JsonMask.cs
+++ b/src/JsonDataMaskingFramework/Masks/JsonMask.cs
@@ -96,7 +96,13 @@ namespace JsonDataMaskingFramework.Masks
         private static void MaskClassProperty<T>(T data, PropertyInfo property)
         {
             var maskedNestedPropertyValue = MaskPropertiesWithSensitiveDataAttribute(property.GetValue(data));
-            property.SetValue(data, maskedNestedPropertyValue);
+            if (!IsPropertyTypeEqualsToAnonymousType(property))
+                property.SetValue(data, maskedNestedPropertyValue);
+        }
+
+        private static bool IsPropertyTypeEqualsToAnonymousType(PropertyInfo property)
+        {
+            return property.ReflectedType.AssemblyQualifiedName.Contains("AnonymousType");
         }
 
         private static void MaskIEnumerableProperty<T>(T data, PropertyInfo property)
@@ -109,7 +115,7 @@ namespace JsonDataMaskingFramework.Masks
             foreach (var value in collection)
             {
                 if (collectionType is null) collectionType = value.GetType();
-                
+
                 object maskedCollectionValue = null;
                 if (IsClassReferenceType(collectionType))
                     maskedCollectionValue = MaskPropertiesWithSensitiveDataAttribute(value);


### PR DESCRIPTION
fix: Add error type handling for anonymous type

A test to validate this case was also added.

It solves this error when trying to mask an object like the test case:
`System.ArgumentException
  HResult=0x80070057
  Message=Método do conjunto de propriedades não encontrado.`

Issue: CN-3013